### PR TITLE
Fix code formatting in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,9 @@ Usage
 
 1. Run ``pip install django-redis-cache``.
 
-2. Modify your Django settings to use ``redis_cache`` :
+2. Modify your Django settings to use ``redis_cache``.
+
+.. code:: python
 
     # When using TCP connections
     CACHES = {


### PR DESCRIPTION
Make sure that Python code in README shows up properly. This fixes a regression caused by 7e747fbea747d8f8774caa5072af8ed6b5e3a716.
